### PR TITLE
Fix a bug when upgrade go mods

### DIFF
--- a/casbin/casbin.go
+++ b/casbin/casbin.go
@@ -43,7 +43,7 @@ func (c *CasbinService) UpdateCasbinApi(oldPath string, newPath string, oldMetho
 
 func (c *CasbinService) GetPolicyPathByRoleId(roleKey string) []CasbinRule {
 	e := c.GetCasbinEnforcer()
-	list := e.GetFilteredPolicy(0, roleKey)
+	list, _ := e.GetFilteredPolicy(0, roleKey)
 	pathMaps := make([]CasbinRule, len(list))
 	for i, v := range list {
 		pathMaps[i] = CasbinRule{


### PR DESCRIPTION
e.GetFilteredPolicy(0, roleKey) returns two values after upgrade.